### PR TITLE
Fix custom events logging issue

### DIFF
--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
@@ -23,6 +23,7 @@ import io.micronaut.core.beans.BeanIntrospector;
 import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Singleton
 public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtractor {
@@ -43,7 +44,9 @@ public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtra
         Map<String, Object> map = new HashMap<>(propertyNames.length - 1);
 
         for (String name : propertyNames) {
-            map.put(name, introspection.getProperty(name).map(p -> p.get(event)).orElse(null));
+            introspection.getProperty(name)
+                .flatMap(p -> Optional.ofNullable(p.get(event)))
+                .ifPresent(v -> map.put(name, v));
         }
 
         map.computeIfAbsent("eventType", k -> introspection.getBeanType().getSimpleName());

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
@@ -46,6 +46,7 @@ public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtra
         for (String name : propertyNames) {
             introspection.getProperty(name)
                 .flatMap(p -> Optional.ofNullable(p.get(event)))
+                .map(v -> (v instanceof Boolean || v instanceof Number) ? v : String.valueOf(v))
                 .ifPresent(v -> map.put(name, v));
         }
 


### PR DESCRIPTION
```
Dec 22 10:15:19 ip-10-0-11-126 server: 2020-12-22T10:15:19,853+0000 [3824 85] com.newrelic WARN: Custom event with invalid attributes key or value of null was reported for a transaction but ignored. Each key should be a String and each value should be a String, Number, or Boolean.
```