### PR TITLE
[sc71208] simplify NewRelicAgentPresentCondition to reflective calls

### DIFF
--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicAgentPresentCondition.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicAgentPresentCondition.java
@@ -20,20 +20,23 @@ package com.agorapulse.micronaut.newrelic;
 import io.micronaut.context.condition.Condition;
 import io.micronaut.context.condition.ConditionContext;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class NewRelicAgentPresentCondition implements Condition {
 
     @Override
     public boolean matches(ConditionContext context) {
         try {
-            Class<?> newRelicAgent = Class.forName("com.newrelic.api.agent.Agent");
-            Object agent = context.getBeanContext().getBean(newRelicAgent);
+            Class<?> newRelic = Class.forName("com.newrelic.api.agent.NewRelic");
+            Object agent = newRelic.getMethod("getAgent").invoke(null);
             boolean isNoop = agent.getClass().getSimpleName().toLowerCase().contains("noop");
             if (isNoop) {
                 context.fail("NewRelic agent is NoOpAgent");
                 return false;
             }
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
             return false;
         }
     }

--- a/test-projects/nr/nr.gradle
+++ b/test-projects/nr/nr.gradle
@@ -33,4 +33,5 @@ dependencies {
     testImplementation platform("io.micronaut:micronaut-bom:$micronautVersion")
     testImplementation 'io.micronaut:micronaut-inject-groovy'
     testImplementation 'io.micronaut.test:micronaut-test-spock'
+    testImplementation 'org.mockito:mockito-inline:3.8.0'
 }

--- a/test-projects/nr/src/test/groovy/nr/NewRelicLibSpec.groovy
+++ b/test-projects/nr/src/test/groovy/nr/NewRelicLibSpec.groovy
@@ -23,8 +23,11 @@ import com.agorapulse.micronaut.newrelic.NewRelicInsightsEvent
 import com.agorapulse.micronaut.newrelic.NewRelicInsightsService
 import com.newrelic.api.agent.Agent
 import com.newrelic.api.agent.Insights
+import com.newrelic.api.agent.NewRelic
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.Introspected
+import org.mockito.MockedStatic
+import org.mockito.Mockito
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -44,6 +47,7 @@ class NewRelicLibSpec extends Specification {
     public static final Long VALUE = 42L
 
     @AutoCleanup ApplicationContext context
+    @AutoCleanup MockedStatic<NewRelic> newRelic = Mockito.mockStatic(NewRelic)
 
     NewRelicInsightsService service
 
@@ -51,6 +55,7 @@ class NewRelicLibSpec extends Specification {
     Insights insights = Mock()
 
     void setup() {
+        newRelic.when { NewRelic.getAgent() } thenReturn(agent)
         context = ApplicationContext.builder().build()
 
         context.registerSingleton(Agent, agent)

--- a/test-projects/nr/src/test/groovy/nr/NewRelicNoopSpec.groovy
+++ b/test-projects/nr/src/test/groovy/nr/NewRelicNoopSpec.groovy
@@ -17,12 +17,9 @@
  */
 package nr
 
-import com.agorapulse.micronaut.newrelic.AsyncNewRelicInsightsService
 import com.agorapulse.micronaut.newrelic.FallbackNewRelicInsightsService
 import com.agorapulse.micronaut.newrelic.NewRelicInsightsClient
 import com.agorapulse.micronaut.newrelic.NewRelicInsightsService
-import com.newrelic.api.agent.Agent
-import com.newrelic.api.agent.Insights
 import io.micronaut.context.ApplicationContext
 import spock.lang.Specification
 
@@ -39,20 +36,6 @@ class NewRelicNoopSpec extends Specification {
         expect:
             !context.containsBean(NewRelicInsightsClient)
             service instanceof FallbackNewRelicInsightsService
-        cleanup:
-            context.close()
-    }
-
-    void 'default new relic instance is enabled if there is valid agent'() {
-        given:
-            ApplicationContext context = ApplicationContext.builder().build()
-            context.registerSingleton(Agent, Mock(Agent))
-            context.registerSingleton(Insights, Mock(Insights))
-            context.start()
-            NewRelicInsightsService service = context.getBean(NewRelicInsightsService)
-        expect:
-            !context.containsBean(NewRelicInsightsClient)
-            service instanceof AsyncNewRelicInsightsService
         cleanup:
             context.close()
     }


### PR DESCRIPTION
After this change, the valid configuration is checked directly on the `NewRelic` class using reflective access.