### PR TITLE
Truncate all fields to comply with NR transport limitations

### DIFF
--- a/docs/guide/src/docs/asciidoc/usage.adoc
+++ b/docs/guide/src/docs/asciidoc/usage.adoc
@@ -22,6 +22,12 @@ WARNING: If you use the library in a non-Micronaut environment (e.g., Grails), e
 The events can optionally implement the `NewRelicInsightsEvent` interface,
 which let you fine-tune the `eventType` and `timestamp` properties.
 
+All event values are truncated to comply to the NewRelic Insights API limits:
+
+* 255 characters when agent is used
+* 4096 characters when using the API directly. +
+https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general
+
 You can have getters annotated with `@Flatten` to include them in the event.
 Those getters should return a `Map<String, Object>`.
 Then all the entries in the map will be included in the event.

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/AsyncNewRelicInsightsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/AsyncNewRelicInsightsService.java
@@ -21,10 +21,10 @@ import com.newrelic.api.agent.Insights;
 import com.newrelic.api.agent.NewRelic;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
-
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 import jakarta.validation.Valid;
+
 import java.util.Collection;
 import java.util.Map;
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
@@ -17,6 +17,7 @@
  */
 package com.agorapulse.micronaut.newrelic;
 
+import com.agorapulse.micronaut.newrelic.limitation.NewRelicLimitationsService;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanIntrospector;
 import jakarta.inject.Singleton;
@@ -28,6 +29,11 @@ import java.util.Map;
 public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtractor {
 
     private final BeanIntrospector introspector = BeanIntrospector.SHARED;
+    private final NewRelicLimitationsService limitationsService;
+
+    public BeanIntrospectionEventPayloadExtractor(NewRelicLimitationsService limitationsService) {
+        this.limitationsService = limitationsService;
+    }
 
     @Override
     @SuppressWarnings("unchecked")
@@ -56,6 +62,9 @@ public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtra
         map.computeIfAbsent("eventType", k -> introspection.getBeanType().getSimpleName());
         map.computeIfAbsent("timestamp", k -> System.currentTimeMillis());
         map.computeIfAbsent("critical", k -> introspection.findAnnotation(Critical.class).isPresent());
+
+        map.replaceAll((k, v) -> limitationsService.truncateValue(v));
+
         return map;
     }
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/DefaultNewRelicInsightsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/DefaultNewRelicInsightsService.java
@@ -20,7 +20,6 @@ package com.agorapulse.micronaut.newrelic;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
-
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 import jakarta.validation.ConstraintViolationException;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/FallbackNewRelicInsightsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/FallbackNewRelicInsightsService.java
@@ -20,12 +20,12 @@ package com.agorapulse.micronaut.newrelic;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.Secondary;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.micronaut.core.annotation.NonNull;
 import jakarta.inject.Singleton;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicConfiguration.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicConfiguration.java
@@ -18,7 +18,6 @@
 package com.agorapulse.micronaut.newrelic;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
-
 import io.micronaut.core.annotation.Nullable;
 import org.slf4j.event.Level;
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicFactory.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicFactory.java
@@ -23,7 +23,6 @@ import com.newrelic.api.agent.NewRelic;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
-
 import jakarta.inject.Singleton;
 
 @Factory

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsClientFilter.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsClientFilter.java
@@ -18,15 +18,15 @@
 package com.agorapulse.micronaut.newrelic;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
+import jakarta.inject.Singleton;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import io.micronaut.core.annotation.Nullable;
-import jakarta.inject.Singleton;
 
 @Singleton
 @NewRelicInsights

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsEvent.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsEvent.java
@@ -18,7 +18,6 @@
 package com.agorapulse.micronaut.newrelic;
 
 import io.micronaut.core.annotation.Introspected;
-
 import io.micronaut.core.beans.BeanIntrospector;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/NewRelicInsightsService.java
@@ -17,10 +17,10 @@
  */
 package com.agorapulse.micronaut.newrelic;
 
-import io.micronaut.validation.Validated;
-
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.validation.Validated;
 import jakarta.validation.Valid;
+
 import java.util.Collection;
 import java.util.Collections;
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2022-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.newrelic.limitation;
 
 import com.agorapulse.micronaut.newrelic.AsyncNewRelicInsightsService;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
@@ -1,0 +1,18 @@
+package com.agorapulse.micronaut.newrelic.limitation;
+
+import com.agorapulse.micronaut.newrelic.AsyncNewRelicInsightsService;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Requires(beans = AsyncNewRelicInsightsService.class)
+@Singleton
+public class AsyncNewRelicLimitationsService implements NewRelicLimitationsService {
+
+    // https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general
+    private static final int MAX_VALUE_LENGTH = 255;
+
+    @Override
+    public int getMaxValueLength() {
+        return MAX_VALUE_LENGTH;
+    }
+}

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/AsyncNewRelicLimitationsService.java
@@ -18,10 +18,12 @@
 package com.agorapulse.micronaut.newrelic.limitation;
 
 import com.agorapulse.micronaut.newrelic.AsyncNewRelicInsightsService;
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 @Requires(beans = AsyncNewRelicInsightsService.class)
+@Replaces(FallbackNewRelicLimitationsService.class)
 @Singleton
 public class AsyncNewRelicLimitationsService implements NewRelicLimitationsService {
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
@@ -1,0 +1,20 @@
+package com.agorapulse.micronaut.newrelic.limitation;
+
+import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Primary
+@Requires(beans = DefaultNewRelicInsightsService.class)
+@Singleton
+public class DefaultNewRelicLimitationsService implements NewRelicLimitationsService {
+
+    // https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general
+    private static final int MAX_VALUE_LENGTH = 4096;
+
+    @Override
+    public int getMaxValueLength() {
+        return MAX_VALUE_LENGTH;
+    }
+}

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2022-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.newrelic.limitation;
 
 import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/DefaultNewRelicLimitationsService.java
@@ -19,11 +19,13 @@ package com.agorapulse.micronaut.newrelic.limitation;
 
 import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;
 import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 @Primary
 @Requires(beans = DefaultNewRelicInsightsService.class)
+@Replaces(FallbackNewRelicLimitationsService.class)
 @Singleton
 public class DefaultNewRelicLimitationsService implements NewRelicLimitationsService {
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
@@ -17,13 +17,13 @@
  */
 package com.agorapulse.micronaut.newrelic.limitation;
 
-import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;
+import com.agorapulse.micronaut.newrelic.FallbackNewRelicInsightsService;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 @Primary
-@Requires(beans = DefaultNewRelicInsightsService.class)
+@Requires(beans = FallbackNewRelicInsightsService.class)
 @Singleton
 public class FallbackNewRelicLimitationsService implements NewRelicLimitationsService {
 

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
@@ -1,0 +1,17 @@
+package com.agorapulse.micronaut.newrelic.limitation;
+
+import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Primary
+@Requires(beans = DefaultNewRelicInsightsService.class)
+@Singleton
+public class FallbackNewRelicLimitationsService implements NewRelicLimitationsService {
+
+    @Override
+    public int getMaxValueLength() {
+        return Integer.MAX_VALUE;
+    }
+}

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/FallbackNewRelicLimitationsService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2022-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.newrelic.limitation;
 
 import com.agorapulse.micronaut.newrelic.DefaultNewRelicInsightsService;

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/NewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/NewRelicLimitationsService.java
@@ -1,0 +1,16 @@
+package com.agorapulse.micronaut.newrelic.limitation;
+
+public interface NewRelicLimitationsService {
+
+    default Object truncateValue(Object value) {
+        if (value instanceof String valueString) {
+            if (valueString.length() <= getMaxValueLength()) {
+                return valueString;
+            }
+            return valueString.substring(0, getMaxValueLength());
+        }
+        return value;
+    }
+
+    int getMaxValueLength();
+}

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/NewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/limitation/NewRelicLimitationsService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2022-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.newrelic.limitation;
 
 public interface NewRelicLimitationsService {

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
@@ -17,8 +17,7 @@
  */
 package com.agorapulse.micronaut.newrelic
 
-import com.agorapulse.micronaut.newrelic.limitation.NewRelicLimitationsService
-import io.micronaut.test.annotation.MockBean
+
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
@@ -28,12 +27,6 @@ class BeanIntrospectionEventPayloadExtractorSpec extends Specification {
 
     @Inject
     BeanIntrospectionEventPayloadExtractor extractor
-//
-//    @MockBean(NewRelicLimitationsService)
-//    NewRelicLimitationsService newRelicLimitationsService = Mock(NewRelicLimitationsService) {
-//        getMaxValueLength() >> TEST_MAX_VALUE_LENGTH
-//        truncateValue()
-//    }
 
     void 'extract payload from event with Flatten'() {
         given:

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
@@ -17,7 +17,6 @@
  */
 package com.agorapulse.micronaut.newrelic
 
-
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
@@ -103,4 +102,5 @@ class BeanIntrospectionEventPayloadExtractorSpec extends Specification {
             payload.firstKey.length() == TestNewRelicLimitationsService.MAX_VALUE_LENGTH
             payload.firstKey == truncatedFirstValue
     }
+
 }

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2022-2024 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.newrelic;
 
 import com.agorapulse.micronaut.newrelic.limitation.FallbackNewRelicLimitationsService;

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
@@ -4,7 +4,6 @@ import com.agorapulse.micronaut.newrelic.limitation.FallbackNewRelicLimitationsS
 import com.agorapulse.micronaut.newrelic.limitation.NewRelicLimitationsService;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Replaces;
-import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 
 @Primary

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/TestNewRelicLimitationsService.java
@@ -1,0 +1,21 @@
+package com.agorapulse.micronaut.newrelic;
+
+import com.agorapulse.micronaut.newrelic.limitation.FallbackNewRelicLimitationsService;
+import com.agorapulse.micronaut.newrelic.limitation.NewRelicLimitationsService;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Primary
+@Replaces(FallbackNewRelicLimitationsService.class)
+@Singleton
+public class TestNewRelicLimitationsService implements NewRelicLimitationsService {
+
+    public static final int MAX_VALUE_LENGTH = 20;
+
+    @Override
+    public int getMaxValueLength() {
+        return MAX_VALUE_LENGTH;
+    }
+}


### PR DESCRIPTION
Newrelic has limitations on the size of the values sent in custom events.
It depends on the way the events are sent: https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general