### PR TITLE
[sc134473] Ignore attributes with null value in sent event

### DIFF
--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractor.java
@@ -50,11 +50,14 @@ public class BeanIntrospectionEventPayloadExtractor implements EventPayloadExtra
 
         for (String name : propertyNames) {
             introspection.getProperty(name).ifPresent(property -> {
-                boolean isFlatten = property.getAnnotationMetadata().isAnnotationPresent(Flatten.class.getName());
-                if (!isFlatten) {
-                    map.put(name, getValueWithSupportedType(property.get(event)));
-                } else {
-                    setFlattenProperties(property.get(event), map);
+                Object propertyValue = property.get(event);
+                if (propertyValue != null) {
+                    boolean isFlatten = property.getAnnotationMetadata().isAnnotationPresent(Flatten.class.getName());
+                    if (!isFlatten) {
+                        map.put(name, getValueWithSupportedType(propertyValue));
+                    } else {
+                        setFlattenProperties(propertyValue, map);
+                    }
                 }
             });
         }

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
@@ -103,4 +103,17 @@ class BeanIntrospectionEventPayloadExtractorSpec extends Specification {
             payload.firstKey == truncatedFirstValue
     }
 
+    void 'extract payload from event with a null attribute value'() {
+        given:
+            String message = null
+            TestEvent event = new TestEvent(message, null)
+        when:
+            Map<String, Object> payload = extractor.extractPayload(event)
+        then:
+            noExceptionThrown()
+            payload.eventType == 'TestEvent'
+            payload.timestamp
+            !payload.containsKey('message')
+    }
+
 }

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
@@ -115,5 +115,4 @@ class BeanIntrospectionEventPayloadExtractorSpec extends Specification {
             payload.timestamp
             !payload.containsKey('message')
     }
-
 }

--- a/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
+++ b/libs/micronaut-newrelic/src/test/groovy/com/agorapulse/micronaut/newrelic/BeanIntrospectionEventPayloadExtractorSpec.groovy
@@ -115,4 +115,5 @@ class BeanIntrospectionEventPayloadExtractorSpec extends Specification {
             payload.timestamp
             !payload.containsKey('message')
     }
+
 }


### PR DESCRIPTION
Ignore attributes with null value in sent event in order to fix below warnings : 
`2024-07-16T10:50:08,769+0000 [1 73] com.newrelic WARN: Custom event [InboxAccountSync] with invalid attributes key or value of null was reported for a transaction but ignored. Each key should be a String and each value should be a String, Number, or Boolean. Key: errorMessage / Value: [null]`