### PR TITLE
Upgrade micronaut-newrelic to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,3 +1,21 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2020-2026 Agorapulse.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Check
 
 on: [ push, pull_request ]
@@ -5,15 +23,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
-      - uses: gradle/gradle-command-action@v2
-        with:
-          arguments: check coveralls
+          java-version: 25
+          distribution: zulu
+      - uses: gradle/actions/setup-gradle@v5
+      - run: ./gradlew check

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -9,19 +9,28 @@ jobs:
     env:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          distribution: zulu
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@v5
       - name: Get Latest Release
         id: latest_version
         uses: abatilo/release-info-action@v1.3.0
         with:
           owner: agorapulse
           repo: micronaut-newrelic
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Publish GitHub Pages
-        uses: gradle/gradle-command-action@v2
-        with:
-          arguments: gitPublishPush -Pversion=${{ steps.latest_version.outputs.latest_tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        env:
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush \
+            -Pversion=${{ steps.latest_version.outputs.latest_tag }} \
+            -Prelease=true \
+            --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,18 +23,23 @@ jobs:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
       - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Release
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
           ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
             -Pversion=${{ steps.version.outputs.tag }} \
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
             -Prelease=true \
-            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
             --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: "-Xmx6g -Xms4g"
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          java-version: 25
+          distribution: zulu
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -29,12 +22,20 @@ jobs:
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
+      - uses: gradle/actions/setup-gradle@v5
       - name: Release
         env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        uses: gradle/gradle-command-action@v2
-        with:
-          arguments: gitPublishPush publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
+            -Pversion=${{ steps.version.outputs.tag }} \
+            -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
+            -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
+            -Prelease=true \
+            -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }} \
+            --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
@@ -46,7 +47,7 @@ jobs:
           - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -56,4 +57,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-newrelic", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.newrelic.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-newrelic", "micronautCompatibility": [5], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.newrelic.version", "github" : ${{ toJson(github) }} }'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://github.com/agorapulse/micronaut-newrelic/workflows/Check/badge.svg)](https://github.com/agorapulse/micronaut-newrelic/actions)
 [![Maven Central](https://img.shields.io/maven-central/v/com.agorapulse/micronaut-newrelic.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.agorapulse%22%20AND%20a:%22micronaut-newrelic%22)
-[![Coverage Status](https://coveralls.io/repos/github/agorapulse/micronaut-newrelic/badge.svg?branch=master)](https://coveralls.io/github/agorapulse/micronaut-newrelic?branch=master)
 
 Micronaut Newrelic Library
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 plugins {
+    id 'lifecycle-base'
     id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@
  */
 plugins {
     id 'lifecycle-base'
-    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
-    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
@@ -87,8 +85,4 @@ subprojects {
             sign publishing.publications
         }
     }
-}
-
-tasks.named('check') {
-    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2022-2024 Agorapulse.
+ * Copyright 2022-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
-    id 'io.github.gradle-nexus.publish-plugin'
+    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
+    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
@@ -29,170 +26,30 @@ if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System
 if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
 if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Newrelic'
-        vendor      = 'Agorapulse'
-        description = 'Micronaut Newrelic Library'
-
-        links {
-            website      = "https://github.com/" + slug
-            issueTracker = "https://github.com/" + slug + "/issues"
-            scm          = "https://github.com/" + slug + ".git"
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localRelease'
-                url  = "" + project.rootProject.buildDir + "/repos/local/release"
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = "" + project.rootProject.buildDir + "/repos/local/snapshot"
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled =  true
-            keyId = signingKeyId
-            secretKey = signingSecretKey
-            password = signingPassword
-        }
-        releasesRepository  = 'localRelease'
-        snapshotsRepository = 'localSnapshot'
-    }
-
-    quality {
-        checkstyle {
-            toolVersion = '8.27'
-        }
-
-        codenarc {
-            toolVersion = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            autoLinks {
-                enabled = false
-            }
-            aggregate {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
-            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
-            username = ossrhUsername
-            password = ossrhPassword
-        }
-    }
-}
-
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://repo.spring.io/release"  }
-    }
-
-    license {
-        exclude '**/*.json'
-        exclude '***.yml'
     }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['libs', 'test-projects']) {
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(17)
-                }
-            }
-
-            micronaut {
-                importMicronautPlatform = true
-                testRuntime 'spock'
-                processing {
-                    incremental false
-                }
-            }
-
-            // useful for Micronaut
-            tasks.withType(GroovyCompile) {
-                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-            }
-
-            // useful for Micronaut
-            tasks.withType(JavaCompile){
-                options.encoding = "UTF-8"
-                options.compilerArgs.add('-parameters')
-            }
-
-            // location independent tests (useful for stable CI builds)
-            tasks.withType(Test){
-                useJUnitPlatform()
-
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            // useful for IntelliJ
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-
-            dependencies {
-                testCompileOnly 'io.micronaut:micronaut-inject-groovy'
-                testImplementation 'io.github.cjstehno.ersatz:ersatz:4.0.0'
-                testImplementation 'io.github.cjstehno.ersatz:ersatz-groovy:4.0.0'
+subprojects {
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            importMicronautPlatform = true
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
         }
 
-        dir('libs') {
-            config {
-                publishing {
-                    enabled = true
-                }
-            }
+        dependencies {
+            testCompileOnly 'io.micronaut:micronaut-inject-groovy'
+            testImplementation 'io.github.cjstehno.ersatz:ersatz:4.0.0'
+            testImplementation 'io.github.cjstehno.ersatz:ersatz-groovy:4.0.0'
         }
     }
 }
 
-
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')
+tasks.named('check') {
+    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,11 @@ plugins {
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
-if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('ossrhPassword'))      ext.ossrhPassword       = System.getenv('SONATYPE_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
 allprojects {
     repositories {
@@ -46,6 +46,44 @@ subprojects {
             testCompileOnly 'io.micronaut:micronaut-inject-groovy'
             testImplementation 'io.github.cjstehno.ersatz:ersatz:4.0.0'
             testImplementation 'io.github.cjstehno.ersatz:ersatz-groovy:4.0.0'
+        }
+    }
+
+    plugins.withId('com.vanniktech.maven.publish') {
+        mavenPublishing {
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            pom {
+                name = 'Micronaut NewRelic'
+                description = 'NewRelic Insights integration for Micronaut applications'
+                inceptionYear = '2020'
+                url = "https://github.com/${slug}"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'musketyr'
+                        name = 'Vladimir Orany'
+                        url = 'https://github.com/musketyr/'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${slug}.git"
+                    connection = "scm:git:git://github.com/${slug}.git"
+                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                }
+            }
+        }
+
+        signing {
+            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+            sign publishing.publications
         }
     }
 }

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -19,6 +19,14 @@ plugins {
     id 'com.agorapulse.gradle.guide'
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 asciidoctor {
     baseDirFollowsSourceDir()
 

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2022-2024 Agorapulse.
+ * Copyright 2022-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,41 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("org.ajoberstar.grgit:grgit-core:$grgitVersion")
-    }
-}
-
 plugins {
-    id 'org.kordamp.gradle.guide'
-    id 'org.ajoberstar.git-publish'
-}
-
-config {
-    docs {
-        guide {
-            publish {
-                enabled = true
-            }
-        }
-    }
-}
-
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
+    id 'com.agorapulse.gradle.guide'
 }
 
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [
@@ -58,5 +28,4 @@ asciidoctor {
         'root-dir': rootDir,
         'project-slug': slug
     ]
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
-nexusPluginVersion=1.0.0
+mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 
-micronautVersion = 4.2.0
-micronautGradlePluginVersion = 4.2.0
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0
 grgitVersion=5.0.0
 spockVersion=2.0-groovy-2.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ javaVersion = 25
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2022-2024 Agorapulse.
+# Copyright 2022-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,16 +16,21 @@
 # limitations under the License.
 #
 
+org.gradle.caching=true
+
 slug=agorapulse/micronaut-newrelic
 group=com.agorapulse
 version=2.0.0-SNAPSHOT
-kordampPluginVersion=0.51.0
-gitPublishPluginVersion=2.1.3
+
+javaVersion = 25
+
+agorapulseGradlePluginsVersion = 4.4.2
+agorapulseAggregateReportsVersion = 4.0.0-rc3
 nexusPluginVersion=1.0.0
+gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 
 micronautVersion = 4.2.0
 micronautGradlePluginVersion = 4.2.0
-micronautGrailsVersion=3.1.0-micronaut-1.0
 grgitVersion=5.0.0
 spockVersion=2.0-groovy-2.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ version=2.0.0-SNAPSHOT
 javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
-agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/micronaut-newrelic-http/micronaut-newrelic-http.gradle
+++ b/libs/micronaut-newrelic-http/micronaut-newrelic-http.gradle
@@ -23,7 +23,8 @@ dependencies {
     api project(':micronaut-newrelic')
     api 'io.micronaut:micronaut-http'
     api 'com.newrelic.agent.java:newrelic-api:4.9.0'
-    api 'io.reactivex.rxjava2:rxjava'
+
+    implementation 'io.projectreactor:reactor-core'
 
     testImplementation 'io.micronaut:micronaut-http-server-netty'
     testImplementation 'com.agorapulse:gru-micronaut:2.0.4'

--- a/libs/micronaut-newrelic-http/src/main/java/com/agorapulse/micronaut/newrelic/http/NewRelicFilter.java
+++ b/libs/micronaut-newrelic-http/src/main/java/com/agorapulse/micronaut/newrelic/http/NewRelicFilter.java
@@ -24,8 +24,8 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
-import io.reactivex.Flowable;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -35,11 +35,11 @@ public class NewRelicFilter implements HttpServerFilter {
     @Override
     public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
         AtomicReference<Token> token = new AtomicReference<>();
-        return Flowable.fromCallable(() -> {
+        return Flux.defer(() -> {
             String templateOrUri = request.getAttribute(HttpAttributes.URI_TEMPLATE, String.class).orElseGet(() -> request.getUri().toString());
             token.set(NewRelicUtil.startTransaction(templateOrUri));
-            return true;
-        }).switchMap(any -> chain.proceed(request)).doOnNext(resp -> {
+            return chain.proceed(request);
+        }).doOnNext(resp -> {
             token.get().expire();
         });
     }

--- a/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/FallbackNewRelicInsightsService.java
+++ b/libs/micronaut-newrelic/src/main/java/com/agorapulse/micronaut/newrelic/FallbackNewRelicInsightsService.java
@@ -17,11 +17,10 @@
  */
 package com.agorapulse.micronaut.newrelic;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.json.JsonMapper;
 import io.micronaut.runtime.context.scope.Refreshable;
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent;
 import jakarta.inject.Singleton;
@@ -29,6 +28,7 @@ import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
@@ -45,11 +45,11 @@ public class FallbackNewRelicInsightsService implements NewRelicInsightsService,
     private static final Logger LOGGER = LoggerFactory.getLogger(NewRelicInsightsService.class);
 
     private final EventPayloadExtractor extractor;
-    private final ObjectMapper mapper;
+    private final JsonMapper mapper;
     private final Deque<Object> events = new ArrayDeque<>();
 
     public FallbackNewRelicInsightsService(EventPayloadExtractor extractor,
-                                           ObjectMapper mapper) {
+                                           JsonMapper mapper) {
         this.extractor = extractor;
         this.mapper = mapper;
     }
@@ -63,7 +63,7 @@ public class FallbackNewRelicInsightsService implements NewRelicInsightsService,
     public <E> void createEvents(Collection<E> events) {
         try {
             List<Map<String, Object>> payloads = events.stream().map(extractor::extractPayload).toList();
-            LOGGER.info("Following events not sent to NewRelic:\n{}", mapper.writerWithDefaultPrettyPrinter().writeValueAsString(payloads));
+            LOGGER.info("Following events not sent to NewRelic:\n{}", mapper.writeValueAsString(payloads));
 
             this.events.addAll(events);
 
@@ -72,7 +72,7 @@ public class FallbackNewRelicInsightsService implements NewRelicInsightsService,
             }
 
             LOGGER.info("You can access {} event(s) using FallbackNewRelicInsightsService#getEvents() method.", this.events.size());
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,9 +44,16 @@ buildscript {
 }
 
 plugins {
-    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
+    }
 }
 
 gradleProjects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ pluginManagement {
         id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
     }
 }
 
@@ -38,6 +39,7 @@ buildscript {
         classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
         classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
         classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
+        classpath group: 'com.vanniktech',        name: 'gradle-maven-publish-plugin',  version: mavenCentralPublishPluginVersion
     }
 }
 
@@ -55,6 +57,9 @@ gradleProjects {
             id 'groovy'
             id 'com.agorapulse.gradle.micronaut-library'
             id 'com.agorapulse.gradle.groovy-common-configuration'
+        }
+        dirs(['libs']) {
+            id 'com.vanniktech.maven.publish'
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2022-2024 Agorapulse.
+ * Copyright 2022-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,55 +17,46 @@
  */
 pluginManagement {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
     }
     plugins {
-        id 'org.kordamp.gradle.settings'                version kordampPluginVersion
-        id 'org.kordamp.gradle.groovy-project'          version kordampPluginVersion
-        id 'org.kordamp.gradle.bintray'                 version kordampPluginVersion
-        id 'org.kordamp.gradle.checkstyle'              version kordampPluginVersion
-        id 'org.kordamp.gradle.codenarc'                version kordampPluginVersion
-        id 'org.kordamp.gradle.guide'                   version kordampPluginVersion
-        id 'org.kordamp.gradle.coveralls'               version kordampPluginVersion
-        id 'org.ajoberstar.git-publish'                 version gitPublishPluginVersion
-        id 'io.github.gradle-nexus.publish-plugin'      version nexusPluginVersion
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
     }
 }
 
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
     }
     dependencies {
-        classpath group: 'io.micronaut.gradle', name: 'micronaut-minimal-plugin', version: micronautGradlePluginVersion
+        classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
+        classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
+        classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
     }
 }
 
 plugins {
-    id 'org.kordamp.gradle.settings'
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
 }
 
-gradleEnterprise {
-    buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-    }
-}
-
-projects {
+gradleProjects {
     directories = ['libs', 'docs', 'test-projects']
 
     plugins {
         dirs(['libs', 'test-projects']) {
-            id 'io.micronaut.minimal.library'
             id 'groovy'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
         }
     }
 }
-
 
 rootProject.name = 'micronaut-newrelic-root'


### PR DESCRIPTION
## Micronaut 5.x upgrade

Brings `micronaut-newrelic` to the Micronaut Framework 5.0 baseline (Java 25, Gradle 9.5, Groovy 5, Spock 2.4-groovy-5.0).

## What changed

### Build
- Bumped `micronautVersion` and the Micronaut Gradle plugin to `5.0.0`.
- Gradle wrapper bumped to `9.5.0`; Java toolchain pinned to 25 via `javaVersion=25`.
- Replaced the Kordamp Gradle plugins (`org.kordamp.gradle.*` - unmaintained since 0.54.0 in 2022 and incompatible with Gradle 9.5) with `com.agorapulse.gradle.*` convention plugins (`settings`, `micronaut-library`, `groovy-common-configuration`, `micronaut-compatibility`, `guide`).
- Switched build-scan publishing to the public Develocity (`com.gradle.develocity` -> `gradle.com`).
- Dropped per-library aggregate-test/jacoco-report tasks - the Develocity scan now aggregates everything across both libs (`micronaut-newrelic`, `micronaut-newrelic-http`) and the three test-projects.
- Enabled the local Gradle build cache.
- Dropped the legacy `micronautGrailsVersion=3.1.0-micronaut-1.0` property (Grails-on-Micronaut compat era - out of scope for M5).

### Publishing
- Replaced `io.github.gradle-nexus.publish-plugin` (legacy OSSRH `s01.oss.sonatype.org`, being deprecated by Sonatype) with `com.vanniktech.maven.publish` 0.34.0 publishing through the new Central Portal.
- Centralised the `mavenPublishing { publishToMavenCentral(true); signAllPublications(); pom { ... } }` + `signing { useInMemoryPgpKeys(...) }` block in the root build so each lib subproject keeps just its dependencies. Only the `libs/` subprojects publish - `test-projects/` are intentionally excluded.
- Release workflow task simplified from `publishToSonatype` + `closeAndReleaseSonatypeStagingRepository` to the single `publishAndReleaseToMavenCentral`. Credentials are now passed as the standard `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` Gradle properties.

### Release workflow
- Modernised actions: `actions/checkout@v4`, `actions/setup-java@v4` (Java 25, Zulu), `gradle/actions/setup-gradle@v5` instead of the deprecated `gradle/gradle-command-action@v2`.
- The downstream `ping` job is now gated on `!github.event.release.prerelease` so RC / SNAPSHOT releases don't notify consumers.
- Marks the artifact as Micronaut 5-compatible in the downstream notification payload.
- `gitPublishPush` credentials moved off the legacy `GRGIT_USER` / `org.ajoberstar.grgit.auth.username` path (removed in gradle-git-publish 5.x) to the `gitPublish.username` / `gitPublish.password` extension properties, sourced from `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD` env vars set by the workflow.
- Added a `git config --global user.name / user.email` step before the release so `gitPublishCommit` succeeds on the fresh CI runner.
- The same modernization applied to `publish_documentation.yml`.

## Required repository secrets

- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_PASSWORD`

Old `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` are no longer referenced and can be removed after the first verified release.

## Test plan
- [ ] CI `Check` workflow is green on Java 25
- [ ] Publishing a pre-release tag does not trigger the downstream `ping` job
- [ ] Publishing a stable tag pings `agorapulse-bom` and `agorapulse-oss`