### PR TITLE
chore(deps): bump Micronaut to 5.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
 grgitVersion=5.0.0
 spockVersion=2.0-groovy-2.5


### PR DESCRIPTION
Bumps Micronaut to 5.0.6 and the Micronaut Gradle plugin to 5.0.2. Part of the MN 5.0.6 OSS release train (ships as micronaut-newrelic 3.0.0 GA).