### PR TITLE
chore(deps): bump Micronaut to 5.1.0 and fix guide title attributes

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -34,6 +34,9 @@ asciidoctor {
         'gradle-version': project.gradle.gradleVersion,
         'source-highlighter': 'prettify',
         'root-dir': rootDir,
-        'project-slug': slug
+        'project-slug': slug,
+        'project-title': 'Micronaut Newrelic',
+        'project-version': project.version,
+        'project-author': 'Agorapulse'
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 projectReactorVersion = 3.4.18
 
-micronautVersion = 5.0.6
+micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
 grgitVersion=5.0.0
 spockVersion=2.0-groovy-2.5


### PR DESCRIPTION
Bumps Micronaut 5.0.6 -> 5.1.0 (Gradle plugin stays 5.0.2) and fixes the guide rendering literal {project-title}/{project-version}. Ships as micronaut-newrelic 3.0.1.